### PR TITLE
fix so that test makefile runs for z/OS

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -5,7 +5,6 @@
 export ZOPEN_TYPE="TARBALL"
 export ZOPEN_TARBALL_URL="https://github.com/facebook/zstd/archive/refs/tags/v1.5.2.tar.gz"
 export ZOPEN_TARBALL_DEPS="curl gzip make coreutils"
-export ZOPEN_EXTRA_CFLAGS='-qnocsect'
 export ZOPEN_BOOTSTRAP=skip
 export ZOPEN_CONFIGURE=skip
 export ZSTD_NO_ASM=1

--- a/patches/PR1/addzostomakefile.patch
+++ b/patches/PR1/addzostomakefile.patch
@@ -46,3 +46,45 @@ index f77e1b7..385f4a1 100644
  
  HAVE_COLORNEVER = $(shell echo a | egrep --color=never a > /dev/null 2> /dev/null && echo 1 || echo 0)
  EGREP_OPTIONS ?=
+diff --git a/tests/Makefile b/tests/Makefile
+index 132fa7a..b55678c 100644
+--- a/tests/Makefile
++++ b/tests/Makefile
+@@ -1,4 +1,3 @@
+-
+  # ################################################################
+ # Copyright (c) Yann Collet, Facebook, Inc.
+ # All rights reserved.
+@@ -58,15 +57,20 @@ ZSTDMT_OBJ3 := $(subst $(ZSTDDIR)/decompress/,zstdmt_d_,$(ZSTDMT_OBJ2))
+ ZSTDMT_OBJ4 := $(ZSTDMT_OBJ3:.c=.o)
+ ZSTDMT_OBJECTS := $(ZSTDMT_OBJ4:.S=.o)
+ 
++UNAME := $(shell uname)
+ # Define *.exe as extension for Windows systems
+ ifneq (,$(filter Windows%,$(OS)))
+ EXT =.exe
+ MULTITHREAD_CPP = -DZSTD_MULTITHREAD
+-MULTITHREAD_LD  =
++ifneq (,$(filter $(UNAME), OS/390))
++MULTITHREAD_LD  = -pthread
++else
++MULTITHREAD_LD  = 
++endif
+ else
+ EXT =
+ MULTITHREAD_CPP = -DZSTD_MULTITHREAD
+-MULTITHREAD_LD  = -pthread
++MULTITHREAD_LD  = 
+ endif
+ MULTITHREAD = $(MULTITHREAD_CPP) $(MULTITHREAD_LD)
+ 
+@@ -247,8 +251,7 @@ clean:
+ #----------------------------------------------------------------------------------
+ # valgrind tests are validated only for some posix platforms
+ #----------------------------------------------------------------------------------
+-UNAME := $(shell uname)
+-ifneq (,$(filter $(UNAME),Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS AIX))
++ifneq (,$(filter $(UNAME),Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS AIX OS/390))
+ HOST_OS = POSIX
+ 
+ valgrindTest: VALGRIND = valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1


### PR DESCRIPTION
the testing still fails after a couple tests, but at least test runs now:

```
*** zstd command line interface 64-bits v1.5.2, by Yann Collet ***
test : basic compression 
test : basic decompression
tmp.zst : Decoding error (36) : Corrupted block detected 
```